### PR TITLE
correct mlir func syntax

### DIFF
--- a/examples/bfs.mlir
+++ b/examples/bfs.mlir
@@ -1,4 +1,4 @@
-func @bfs(%m1 : memref<?x?xf32>, %m2 : memref<?x?xf32>, %m3 : memref<?x?xf32>)
+func.func @bfs(%m1 : memref<?x?xf32>, %m2 : memref<?x?xf32>, %m3 : memref<?x?xf32>)
 {
   graph.bfs %m1, %m2, %m3 : memref<?x?xf32>, memref<?x?xf32>, memref<?x?xf32> 
   %c0 = arith.constant 0 : index


### PR DESCRIPTION
This PR aims to correct the basic syntax of `func` in `bfs.mlir`, which is causing the linking error during the compilation of the project.